### PR TITLE
Various HTML markup fixes

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,7 +65,7 @@
     
 </div>
 <div class='col-12 col-md-7'>
-    ....
+    …
 </div>
 
 <div class='col-12'>

--- a/community.html
+++ b/community.html
@@ -76,7 +76,7 @@
             อย่างไรก็ตามกฎและกติกากลางจะถูกบังคับใช้ในทุกๆห้อง
             <BR />ทางเข้าห้องจะถูกเปลี่ยนทุกครั้งที่มีการ build/render page ใน server side ใหม่กรุณาส่ง URL <pre>https://thai.anthro.asia/community.html</pre> ให้กับผู้ที่ท่านจะเชิญ
             <ul>
-                <li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#blueModal'>ห้องฟ้า</a> </li><li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#redModal'>ห้องแดง</a> 18+</li>
+                <li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#blueModal'>ห้องฟ้า</button> </li><li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#redModal'>ห้องแดง</button> 18+</li>
             </ul>
 
             <small></small>
@@ -99,7 +99,7 @@
             </div>
             <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <a class="btn btn-primary" href="https://t.me/joinchat/U5a9gTwvdpN86Hl_" target="_blank" rel="noopener noreferrer">Join …</button>
+            <a class="btn btn-primary" href="https://t.me/joinchat/U5a9gTwvdpN86Hl_" target="_blank" rel="noopener noreferrer">Join …</a>
             </div>
         </div>
         </div>
@@ -117,7 +117,7 @@
             </div>
             <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <a class="btn btn-primary" href="https://t.me/joinchat/VMTHzyQyOQfZiXP4" target="_blank" rel="noopener noreferrer">Join …</button>
+            <a class="btn btn-primary" href="https://t.me/joinchat/VMTHzyQyOQfZiXP4" target="_blank" rel="noopener noreferrer">Join …</a>
             </div>
         </div>
         </div>

--- a/community.html
+++ b/community.html
@@ -76,7 +76,7 @@
             อย่างไรก็ตามกฎและกติกากลางจะถูกบังคับใช้ในทุกๆห้อง
             <BR />ทางเข้าห้องจะถูกเปลี่ยนทุกครั้งที่มีการ build/render page ใน server side ใหม่กรุณาส่ง URL <pre>https://thai.anthro.asia/community.html</pre> ให้กับผู้ที่ท่านจะเชิญ
             <ul>
-                <li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#blueModal'>ห้องฟ้า</button> </li><li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#redModal'>ห้องแดง</button> 18+</li>
+                <li><button type="button" class="btn btn-link p-0 m-0 d-inline align-baseline" data-toggle='modal' data-target='#blueModal'>ห้องฟ้า</button> </li><li><button type="button" class="btn btn-link p-0 m-0 d-inline align-baseline" data-toggle='modal' data-target='#redModal'>ห้องแดง</button> 18+</li>
             </ul>
 
             <small></small>

--- a/community.html
+++ b/community.html
@@ -76,7 +76,7 @@
             อย่างไรก็ตามกฎและกติกากลางจะถูกบังคับใช้ในทุกๆห้อง
             <BR />ทางเข้าห้องจะถูกเปลี่ยนทุกครั้งที่มีการ build/render page ใน server side ใหม่กรุณาส่ง URL <pre>https://thai.anthro.asia/community.html</pre> ให้กับผู้ที่ท่านจะเชิญ
             <ul>
-                <li><a href='#' data-toggle='modal' data-target='#blueModal'>ห้องฟ้า</a> </li><li><a href='#' data-toggle='modal' data-target='#redModal'>ห้องแดง</a> 18+</li>
+                <li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#blueModal'>ห้องฟ้า</a> </li><li><button type="button" class="btn btn-link" data-toggle='modal' data-target='#redModal'>ห้องแดง</a> 18+</li>
             </ul>
 
             <small></small>
@@ -99,7 +99,7 @@
             </div>
             <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <button type="button" class="btn btn-primary" onclick="join_telegram('VTVhOWdUd3ZkcE44NkhsXw==');">Join ...</button>
+            <a class="btn btn-primary" href="https://t.me/joinchat/U5a9gTwvdpN86Hl_" target="_blank" rel="noopener noreferrer">Join …</button>
             </div>
         </div>
         </div>
@@ -117,7 +117,7 @@
             </div>
             <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <button type="button" class="btn btn-primary" onclick="join_telegram('Vk1USHp5UXlPUWZaaVhQNA==');">Join ...</button>
+            <a class="btn btn-primary" href="https://t.me/joinchat/VMTHzyQyOQfZiXP4" target="_blank" rel="noopener noreferrer">Join …</button>
             </div>
         </div>
         </div>
@@ -137,13 +137,6 @@
         </div>
     </div>
 </div>
-
-<script>
-    function join_telegram(chatID){
-        window.open('https://t.me/joinchat/'+atob(chatID), '_blank');
-        //alert(chatID);
-    }
-</script>
         <div class="col-12 d-print-none"><hr /></div>
         <div class="col-12 d-print-none"><p><small>©2021 - <a href="index.html">thai.anthro.asia</a> is a homepage of <a href="about.html">แอนโทรไทย</a></small><div class="d-none"> | <small>sitemap: <a href="sitemap.html">html</a>,<a href="sitemap.xml">xml</a></small></div></p></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     ชุมชน<a href="about.html">แอนโทรไทย</a>
 </div>
         <div class="col-12 d-print-none"><hr /></div>
-        <div class="col-12 d-print-none"><p><small>©2021 - <a href="index.html">thai.anthro.asia</a> is a homepage of <a href="about.html">แอนโทรไทย</a></small><div class="d-none"> | <small>sitemap: <a href="sitemap.html">html</a>,<a href="sitemap.xml">xml</a></small></div></p></div>
+        <div class="col-12 d-print-none"><p><small>©2021 - <a href="index.html">thai.anthro.asia</a> is a homepage of <a href="about.html">แอนโทรไทย</a></small><div class="d-none"> | <small>sitemap: <a href="sitemap.html">html</a>,<a href="sitemap.xml">xml</a></small></div></div>
     </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous"></script>

--- a/meeting.html
+++ b/meeting.html
@@ -72,7 +72,7 @@
     <p><ins>ยังไม่มี</ins></p>
 
     <h2>มีตติงในอดีต</h2>
-    <p>...</p>
+    <p>…</p>
 </div>
 
         <div class="col-12 d-print-none"><hr /></div>


### PR DESCRIPTION
- Uses ellipses unicode character `…`
- Correct link/button semantic markups on Telegram link. ("ห้องฟ้า" open a modal, so it should syntactically be a `button`, "Join…" navigates to a different page, so it should be a `a`) On PHP side, `atob()` can be replaced with `base64_decode()`.
- Add `rel="noopener noreferrer"` to Telegram external links. (Up for discussion)
- Remove extra `</p>` at the hidden footer (example shown on only 1 file, I know you will fix that at the template) (Why are there hidden links to sitemap if you don't have one anyway?)